### PR TITLE
add FUZZ_FUNC variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@ which run the libfuzzer and beta fuzzer tests, respectively.
 
 Looping (```loopmagic``` in [fuzz.go](/fuzz.go))
 ```
-docker run --rm fuzztests mage looplibfuzzer
-docker run --rm fuzztests mage loopbetafuzzer
+docker run --rm -e FUZZ_FUNC=FuzzLoop fuzztests mage libfuzzer
+docker run --rm -e FUZZ_FUNC=FuzzLoopBeta fuzztests mage betafuzzer
 ```
 
 
@@ -144,7 +144,7 @@ Error: running "gotip test -fuzz=FuzzBeta" failed with exit code 1
 Finding crashers with a simple loop appears to be about similar in performance between libfuzzer and beta fuzzer.
 
 ```
-docker run --rm fuzztests mage loopbetafuzzer
+docker run --rm -e FUZZ_FUNC=FuzzLoopBeta fuzztests mage betafuzzer
 fuzzing, elapsed: 3.0s, execs: 334297 (111390/sec), workers: 8, interesting: 3
 fuzzing, elapsed: 6.0s, execs: 688004 (114632/sec), workers: 8, interesting: 4
 fuzzing, elapsed: 9.0s, execs: 1037669 (115277/sec), workers: 8, interesting: 4
@@ -165,7 +165,7 @@ FAIL	github.com/stevenjohnstone/fuzztests	15.415s
 
 ```
 ```
-docker run --rm fuzztests mage looplibfuzzer
+docker run --rm -e FUZZ_FUNC=FuzzLoop fuzztests mage libfuzzer
 INFO: Seed: 4224861379
 INFO: 66 Extra Counters
 INFO: -max_len is not provided; libFuzzer will not generate inputs larger than 4096 bytes

--- a/run.go
+++ b/run.go
@@ -34,11 +34,11 @@ func libfuzzer(fuzz string) error {
 }
 
 func Libfuzzer() error {
-	return libfuzzer("Fuzz")
-}
-
-func LoopLibfuzzer() error {
-	return libfuzzer("FuzzLoop")
+	fuzzFunc := os.Getenv("FUZZ_FUNC")
+	if fuzzFunc == "" {
+		fuzzFunc = "Fuzz"
+	}
+	return libfuzzer(fuzzFunc)
 }
 
 func betafuzzer(fuzz string) error {
@@ -56,9 +56,9 @@ func betafuzzer(fuzz string) error {
 }
 
 func Betafuzzer() error {
-	return betafuzzer("FuzzBeta")
-}
-
-func LoopBetafuzzer() error {
-	return betafuzzer("FuzzLoopBeta")
+	fuzzFunc := os.Getenv("FUZZ_FUNC")
+	if fuzzFunc == "" {
+		fuzzFunc = "FuzzBeta"
+	}
+	return betafuzzer(fuzzFunc)
 }


### PR DESCRIPTION
This lets you specify which fuzz function to run with the FUZZ_FUNC variable instead of needing a separate mage target for each one.